### PR TITLE
Some fixes/changes to CreateLinks.bat

### DIFF
--- a/CreateLinks.bat
+++ b/CreateLinks.bat
@@ -1,13 +1,32 @@
 :: Engine source is in a git repo, Klawr source is in a different git repo, no simple way to put the Klawr checkout inside Engine checkout due to a shared directory structure,
 :: so create a couple of directory junctions and a few symbolic links in the Engine source that link to the Klawr source.
+
 @echo off
+color F
+
 set BATCH_FILE_LOCATION=%~dp0
-set ENGINE_SOURCE_LOCATION=C:\Projects\UE4\UnrealEngine\
-@echo on
 
-mklink /J "%ENGINE_SOURCE_LOCATION%Engine\Source\ThirdParty\Klawr" "%BATCH_FILE_LOCATION%Engine\Source\ThirdParty\Klawr"
-mklink /J "%ENGINE_SOURCE_LOCATION%Engine\Plugins\Klawr\KlawrCodeGeneratorPlugin" "%BATCH_FILE_LOCATION%Engine\Plugins\Klawr\KlawrCodeGeneratorPlugin"
-mklink /J "%ENGINE_SOURCE_LOCATION%Engine\Plugins\Klawr\KlawrRuntimePlugin" "%BATCH_FILE_LOCATION%Engine\Plugins\Klawr\KlawrRuntimePlugin"
-mklink /J "%ENGINE_SOURCE_LOCATION%Engine\Plugins\Klawr\KlawrEditorPlugin" "%BATCH_FILE_LOCATION%Engine\Plugins\Klawr\KlawrEditorPlugin"
+:GetDirectory
+set /p ENGINE_SOURCE_LOCATION="Specify Unreal Engine 4 Source Directory: " % = %
 
+if (%ENGINE_SOURCE_LOCATION%) == () (goto GetDirectory)
+
+:CreateJunctions
+echo Creating Engine\Plugins\Klawr Directory...
+mkdir %ENGINE_SOURCE_LOCATION%\Engine\Plugins\Klawr\
+
+echo Creating Engine\Source\ThirdParty\Klawr Junction...
+mklink /J "%ENGINE_SOURCE_LOCATION%\Engine\Source\ThirdParty\Klawr" "%BATCH_FILE_LOCATION%\Engine\Source\ThirdParty\Klawr"
+
+echo Creating Engine\Plugins\Klawr\KlawrCodeGeneratorPlugin Junction...
+mklink /J "%ENGINE_SOURCE_LOCATION%\Engine\Plugins\Klawr\KlawrCodeGeneratorPlugin" "%BATCH_FILE_LOCATION%\Engine\Plugins\Klawr\KlawrCodeGeneratorPlugin"
+
+echo Creating Engine\Plugins\Klawr\KlawrRuntimePlugin Junction...
+mklink /J "%ENGINE_SOURCE_LOCATION%\Engine\Plugins\Klawr\KlawrRuntimePlugin" "%BATCH_FILE_LOCATION%\Engine\Plugins\Klawr\KlawrRuntimePlugin"
+
+echo Creating Engine\Plugins\Klawr\KlawrEditorPlugin Junction...
+mklink /J "%ENGINE_SOURCE_LOCATION%\Engine\Plugins\Klawr\KlawrEditorPlugin" "%BATCH_FILE_LOCATION%\Engine\Plugins\Klawr\KlawrEditorPlugin"
+
+echo Done!
 pause
+


### PR DESCRIPTION
- Make it prompt the user for the UE4 directory instead of making an assumption of where it is and requiring the file to be edited manually
- Add trailing backslashes so that if they are forgotton the junctioning won't immediately fail
- Cleanup/organizational things

Made these changes to our submodule of Klawr for ease of use, thought you might be interested.
